### PR TITLE
Allow quiting running CHIP-8 ROMS and quiting Silicon8 from the menu

### DIFF
--- a/Games/Silicon8/Silicon8.py
+++ b/Games/Silicon8/Silicon8.py
@@ -44,6 +44,8 @@ def runSilicon8():
     while True:
         gc.collect()
         program, index, scroll = menu.Menu(index, scroll).choose(roms.catalog())
+        if not program["file"]:
+            return False
         if menu.Confirm().choose(program):
             break
 
@@ -62,9 +64,10 @@ def runSilicon8():
     thumby.display.fill(0)
     thumby.display.update()
     instance.run(roms.load(program))
+    return True
 
 gc.enable()
 # machine.freq(125000000)
 
-while True:
-    runSilicon8()
+while runSilicon8():
+    pass

--- a/Games/Silicon8/Silicon8.py
+++ b/Games/Silicon8/Silicon8.py
@@ -23,9 +23,9 @@ thumby.display.setFPS(0)
 thumby.display.blit(splash, 0, 0, 72, 40, -1, 0, 0)
 thumby.display.update()
 
-# Fix import path so it finds our modules
+# Fix import path so it finds our modules above all else
 import sys
-sys.path.append('/Games/Silicon8')
+sys.path.insert(0, '/Games/Silicon8')
 
 import time
 import gc
@@ -35,21 +35,28 @@ import roms
 import cpu
 import menu
 
+gc.enable()
+
 index = 0
 scroll = 0
+
+def gb_collect():
+    print("Free memory before garbage collect:", gc.mem_free())
+    gc.collect()
+    print("Free memory after garbage collect:", gc.mem_free())
 
 def runSilicon8():
     global index, scroll
     # Ask user to choose a ROM
     while True:
-        gc.collect()
+        gb_collect()
         program, index, scroll = menu.Menu(index, scroll).choose(roms.catalog())
         if not program["file"]:
             return False
         if menu.Confirm().choose(program):
             break
 
-    gc.collect()
+    gb_collect()
 
     # Instantiate interpreter
     instance = cpu.CPU()
@@ -66,8 +73,7 @@ def runSilicon8():
     instance.run(roms.load(program))
     return True
 
-gc.enable()
-# machine.freq(125000000)
-
 while runSilicon8():
     pass
+
+thumby.reset()

--- a/Games/Silicon8/cpu.py
+++ b/Games/Silicon8/cpu.py
@@ -142,7 +142,7 @@ class CPU:
         prog = ptr8(program)
         for i in range(int(len(program))):
             ram[i + 0x200] = prog[i]
-        while self.running:
+        while self.running and not thumbyinterface.breakCombo():
             self.cycle()
 
     def reset(self, interpreter):

--- a/Games/Silicon8/menu.py
+++ b/Games/Silicon8/menu.py
@@ -8,6 +8,10 @@ class Menu:
 
     def choose(self, programs):
         self.programs = programs
+        self.programs.append({
+            "name": "Quit Silicon8",
+            "file": False
+        })
         while True:
             self.animate = 0
             self.render()

--- a/Games/Silicon8/thumbyinterface.py
+++ b/Games/Silicon8/thumbyinterface.py
@@ -58,3 +58,8 @@ def getKeys():
     if "b" in keymap:
         keyboard[keymap["b"]]     |= thumby.buttonB.pressed()
     return keyboard
+
+# Key combination to quit the running program
+@micropython.viper
+def breakCombo():
+    return thumby.buttonL.pressed() and thumby.buttonA.pressed() and thumby.buttonB.pressed()

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ All fields are optional. Valid options for `type` are `AUTO` (default), `VIP`,
 `right`, `a` and `b` for all the buttons on the Thumby. The numeric values are
 the corresponding keys to be pressed on the CHIP-8 keypad (0 - 15).
 
+You can quit a running CHIP-8 ROM and return to the Silicon8 menu at any time by
+holding down the key combination `LEFT`, `A` and `B`.
+
 ## Known issues
 
 The interpretation of CHIP-8, SCHIP and XO-CHIP should be pretty close to the


### PR DESCRIPTION
Would be nice to have this, but after restarting the interpreter a few times, we get:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Games/Silicon8/Silicon8.py", line 73, in <module>
  File "/Games/Silicon8/Silicon8.py", line 66, in runSilicon8
  File "/Games/Silicon8/cpu.py", line 186, in reset
MemoryError: memory allocation failed, allocating 65535 bytes
```

At least in the Thumby emulator. This needs to be fixed before this is a stable feature.